### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🔍 BuiltWith MCP Server 🚀
 
+[![MCP status](https://mcpvitals.com/badge/446cf8d99f.svg)](https://mcpvitals.com/status/446cf8d99f)
+
 ## 🌟 Overview
 
 **BuiltWith MCP** is a Model Context Protocol (MCP) server that allows AI assistants (Claude, Cursor, IDE agents, etc.) to query BuiltWith’s technology detection data **directly and natively**.


### PR DESCRIPTION
Hi — you operate this endpoint at `api.builtwith.com/mcp`, so its uptime reflects on BuiltWith directly. This adds a badge showing whether it currently completes a real MCP handshake, linked to a public status page.

It's reporting healthy with 48 tools. Purely a README addition, no tracking, and you can close it without explanation if it doesn't fit your docs conventions.

---
*Disclosure: I build MCP Vitals, the service behind this badge — so I have an interest here. I also used an AI assistant to help prepare this PR. The check is real and reproducible without me: `npx @mcpvitals/cli check <your-endpoint>`. Close it freely if it isn't a fit.*